### PR TITLE
Feature/opensl gettimestamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set (oboe_sources
         src/opensles/AudioOutputStreamOpenSLES.cpp
         src/opensles/AudioStreamBuffered.cpp
         src/opensles/AudioStreamOpenSLES.cpp
+		src/opensles/AudioTrack.cpp
         src/opensles/EngineOpenSLES.cpp
         src/opensles/OpenSLESUtilities.cpp
         src/opensles/OutputMixerOpenSLES.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set (oboe_sources
         src/opensles/AudioOutputStreamOpenSLES.cpp
         src/opensles/AudioStreamBuffered.cpp
         src/opensles/AudioStreamOpenSLES.cpp
-		src/opensles/AudioTrack.cpp
+        src/opensles/AudioTrack.cpp
         src/opensles/EngineOpenSLES.cpp
         src/opensles/OpenSLESUtilities.cpp
         src/opensles/OutputMixerOpenSLES.cpp

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -313,7 +313,7 @@ public:
         return this;
     }
 
-    AudioStreamBuilder *setJavaVM(JavaVM &javaVM) {
+    AudioStreamBuilder *setJavaVM(JavaVM *javaVM) {
         mJavaVM = javaVM;
         return this;
     }
@@ -343,7 +343,7 @@ private:
 
     AudioApi       mAudioApi = AudioApi::Unspecified;
 
-    JavaVM mJavaVM;
+    JavaVM *mJavaVM;
 };
 
 } // namespace oboe

--- a/include/oboe/AudioStreamBuilder.h
+++ b/include/oboe/AudioStreamBuilder.h
@@ -17,6 +17,7 @@
 #ifndef OBOE_STREAM_BUILDER_H_
 #define OBOE_STREAM_BUILDER_H_
 
+#include <jni.h>
 #include "oboe/Definitions.h"
 #include "oboe/AudioStreamBase.h"
 
@@ -312,6 +313,11 @@ public:
         return this;
     }
 
+    AudioStreamBuilder *setJavaVM(JavaVM &javaVM) {
+        mJavaVM = javaVM;
+        return this;
+    }
+
     /**
      * Create and open a stream object based on the current settings.
      *
@@ -336,6 +342,8 @@ private:
     oboe::AudioStream *build();
 
     AudioApi       mAudioApi = AudioApi::Unspecified;
+
+    JavaVM mJavaVM;
 };
 
 } // namespace oboe

--- a/src/common/AudioStreamBuilder.cpp
+++ b/src/common/AudioStreamBuilder.cpp
@@ -68,7 +68,7 @@ AudioStream *AudioStreamBuilder::build() {
         stream = new AudioStreamAAudio(*this);
     } else {
         if (getDirection() == oboe::Direction::Output) {
-            stream = new AudioOutputStreamOpenSLES(*this);
+            stream = new AudioOutputStreamOpenSLES(*this, mJavaVM);
         } else if (getDirection() == oboe::Direction::Input) {
             stream = new AudioInputStreamOpenSLES(*this);
         }

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -64,7 +64,7 @@ static SLuint32 OpenSLES_convertOutputUsage(Usage oboeUsage) {
     return openslStream;
 }
 
-AudioOutputStreamOpenSLES::AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder, const JavaVM &javaVM)
+AudioOutputStreamOpenSLES::AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder, JavaVM *javaVM)
         : AudioStreamOpenSLES(builder) {
     mJavaVM = javaVM;
 }

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -476,11 +476,11 @@ Result AudioOutputStreamOpenSLES::getTimestamp(clockid_t clockId, int64_t *frame
 
 ResultWithValue<FrameTimestamp> AudioOutputStreamOpenSLES::getTimestamp(clockid_t clockId) {
     if (mAudioTrack == nullptr) {
-        return Result::ErrorNull;
+        return ResultWithValue<FrameTimestamp>(Result::ErrorNull);
     }
 
     if (!canQueryTimestamp()) {
-        return Result::ErrorUnavailable;
+        return ResultWithValue<FrameTimestamp>(Result::ErrorUnavailable);
     }
 
     auto result = mAudioTrack->getTimestamp();
@@ -505,9 +505,9 @@ ResultWithValue<double> AudioOutputStreamOpenSLES::calculateLatencyMillis() {
                                &hardwareFrameHardwareTime);
     if (result == oboe::Result::ErrorUnavailable && mLastKnownLatency != -1) {
         // timestamp not available, or queried too recently
-        return ResultWithValue(mLastKnownLatency);
+        return ResultWithValue<double>(mLastKnownLatency);
     } else if (result != oboe::Result::OK) {
-        return {(result)};
+        return ResultWithValue<double>(result);
     }
 
     // Get counter closest to the app.

--- a/src/opensles/AudioOutputStreamOpenSLES.cpp
+++ b/src/opensles/AudioOutputStreamOpenSLES.cpp
@@ -62,8 +62,9 @@ static SLuint32 OpenSLES_convertOutputUsage(Usage oboeUsage) {
     return openslStream;
 }
 
-AudioOutputStreamOpenSLES::AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder)
+AudioOutputStreamOpenSLES::AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder, const JavaVM &javaVM)
         : AudioStreamOpenSLES(builder) {
+    mJavaVM = javaVM;
 }
 
 AudioOutputStreamOpenSLES::~AudioOutputStreamOpenSLES() {

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -50,6 +50,8 @@ public:
 
     ResultWithValue<FrameTimestamp> getTimestamp(clockid_t clockId) override;
 
+    ResultWithValue<double> calculateLatencyMillis() override;
+
 protected:
 
     void setFramesRead(int64_t framesRead);
@@ -81,6 +83,7 @@ private:
     JavaVM mJavaVM;
     AudioTrack * mAudioTrack = nullptr;
     int64_t mLastTimestampQuery = -1;
+    double mLastKnownLatency = -1;
 };
 
 } // namespace oboe

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -32,7 +32,7 @@ namespace oboe {
 class AudioOutputStreamOpenSLES : public AudioStreamOpenSLES {
 public:
     AudioOutputStreamOpenSLES();
-    explicit AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder);
+    explicit AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder, const JavaVM &javaVM);
 
     virtual ~AudioOutputStreamOpenSLES();
 
@@ -70,6 +70,7 @@ private:
 
     SLPlayItf      mPlayInterface = nullptr;
 
+    JavaVM mJavaVM;
 };
 
 } // namespace oboe

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -23,6 +23,7 @@
 
 #include "oboe/Oboe.h"
 #include "AudioStreamOpenSLES.h"
+#include "AudioTrack.h"
 
 namespace oboe {
 
@@ -43,6 +44,11 @@ public:
     Result requestPause() override;
     Result requestFlush() override;
     Result requestStop() override;
+
+    Result
+    getTimestamp(clockid_t clockId, int64_t *framePosition, int64_t *timeNanoseconds) override;
+
+    ResultWithValue<FrameTimestamp> getTimestamp(clockid_t clockId) override;
 
 protected:
 
@@ -68,9 +74,13 @@ private:
      */
     Result setPlayState_l(SLuint32 newState);
 
+    bool canQueryTimestamp();
+
     SLPlayItf      mPlayInterface = nullptr;
 
     JavaVM mJavaVM;
+    AudioTrack * mAudioTrack = nullptr;
+    int64_t mLastTimestampQuery = -1;
 };
 
 } // namespace oboe

--- a/src/opensles/AudioOutputStreamOpenSLES.h
+++ b/src/opensles/AudioOutputStreamOpenSLES.h
@@ -33,7 +33,7 @@ namespace oboe {
 class AudioOutputStreamOpenSLES : public AudioStreamOpenSLES {
 public:
     AudioOutputStreamOpenSLES();
-    explicit AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder, const JavaVM &javaVM);
+    explicit AudioOutputStreamOpenSLES(const AudioStreamBuilder &builder, JavaVM *javaVM);
 
     virtual ~AudioOutputStreamOpenSLES();
 
@@ -80,8 +80,8 @@ private:
 
     SLPlayItf      mPlayInterface = nullptr;
 
-    JavaVM mJavaVM;
-    AudioTrack * mAudioTrack = nullptr;
+    JavaVM *mJavaVM = nullptr;
+    AudioTrack *mAudioTrack = nullptr;
     int64_t mLastTimestampQuery = -1;
     double mLastKnownLatency = -1;
 };

--- a/src/opensles/AudioTrack.cpp
+++ b/src/opensles/AudioTrack.cpp
@@ -24,11 +24,12 @@ AudioTrack::~AudioTrack() {
     }
 }
 
-ResultWithValue<AudioTimestamp> AudioTrack::getTimestamp() {
+ResultWithValue<FrameTimestamp> AudioTrack::getTimestamp() {
     JNIEnv* env;
     int envStat = mJavaVM.GetEnv((void **)&env, JNI_VERSION_1_6);
     if (envStat == JNI_EDETACHED) {
         // Cannot get JNIEnv on a thread that is not attached to the JVM
+        // Only call getTimestamp from threads that are already attached
         return oboe::Result::ErrorInvalidState;
     }
 
@@ -55,8 +56,9 @@ ResultWithValue<AudioTimestamp> AudioTrack::getTimestamp() {
         return ResultWithValue(Result::ErrorUnavailable);
     }
 
-    auto framePosition = (int64_t) env->GetLongField(mAudioTimestamp, mFramePositionField);
-    auto nanoTime = (int64_t) env->GetLongField(mAudioTimestamp, mNanoTimeField);
+    FrameTimestamp frame;
+    frame.position = (int64_t) env->GetLongField(mAudioTimestamp, mFramePositionField);
+    frame.timestamp = (int64_t) env->GetLongField(mAudioTimestamp, mNanoTimeField);
 
-    return ResultWithValue(new AudioTimestamp(framePosition, nanoTime));
+    return ResultWithValue(frame);
 }

--- a/src/opensles/AudioTrack.cpp
+++ b/src/opensles/AudioTrack.cpp
@@ -30,7 +30,7 @@ ResultWithValue<FrameTimestamp> AudioTrack::getTimestamp() {
     if (envStat == JNI_EDETACHED) {
         // Cannot get JNIEnv on a thread that is not attached to the JVM
         // Only call getTimestamp from threads that are already attached
-        return oboe::Result::ErrorInvalidState;
+        return ResultWithValue<FrameTimestamp>(Result::ErrorInvalidState);
     }
 
     if (mAudioTimestampClass == nullptr) {
@@ -53,12 +53,12 @@ ResultWithValue<FrameTimestamp> AudioTrack::getTimestamp() {
     jboolean timestampAvailable = env->CallBooleanMethod(mAudioTrack, mGetTimestampID, mAudioTimestamp);
 
     if (timestampAvailable == JNI_FALSE) {
-        return ResultWithValue(Result::ErrorUnavailable);
+        return ResultWithValue<FrameTimestamp>(Result::ErrorUnavailable);
     }
 
     FrameTimestamp frame;
     frame.position = (int64_t) env->GetLongField(mAudioTimestamp, mFramePositionField);
     frame.timestamp = (int64_t) env->GetLongField(mAudioTimestamp, mNanoTimeField);
 
-    return ResultWithValue(frame);
+    return ResultWithValue<FrameTimestamp>(frame);
 }

--- a/src/opensles/AudioTrack.cpp
+++ b/src/opensles/AudioTrack.cpp
@@ -1,0 +1,62 @@
+//
+// Created by Alex Crimi on 2/15/19.
+//
+
+#include "AudioTrack.h"
+
+using namespace oboe;
+
+AudioTrack::AudioTrack(const JavaVM &javaVM, jobject audioTrack) {
+    mJavaVM = javaVM;
+    mAudioTrack = audioTrack;
+}
+
+AudioTrack::~AudioTrack() {
+    JNIEnv* env = nullptr;
+    mJavaVM.GetEnv((void **)&env, JNI_VERSION_1_6);
+    if (env != nullptr) {
+        env->DeleteGlobalRef(mAudioTimestampClass);
+        mAudioTimestampClass = nullptr;
+        env->DeleteGlobalRef(mAudioTimestamp);
+        mAudioTimestamp = nullptr;
+        env->DeleteGlobalRef(mAudioTrackClass);
+        mAudioTrackClass = nullptr;
+    }
+}
+
+ResultWithValue<AudioTimestamp> AudioTrack::getTimestamp() {
+    JNIEnv* env;
+    int envStat = mJavaVM.GetEnv((void **)&env, JNI_VERSION_1_6);
+    if (envStat == JNI_EDETACHED) {
+        // Cannot get JNIEnv on a thread that is not attached to the JVM
+        return oboe::Result::ErrorInvalidState;
+    }
+
+    if (mAudioTimestampClass == nullptr) {
+        // cache AudioTimestamp.java class and fields
+        mAudioTimestampClass = (jclass) env->NewGlobalRef(env->FindClass("android/media/AudioTimestamp"));
+        mFramePositionField = env->GetFieldID(mAudioTimestampClass, "framePosition", "J");
+        mNanoTimeField = env->GetFieldID(mAudioTimestampClass, "nanoTime", "J");
+
+        // create reusable AudioTimestamp.java instance
+        jmethodID newAudioTimestamp = env->GetMethodID(mAudioTimestampClass, "<init>", "()V");
+        mAudioTimestamp = (jobject) env->NewGlobalRef(env->NewObject(mAudioTimestampClass, newAudioTimestamp));
+    }
+
+    if (mAudioTrackClass == nullptr) {
+        // cache AudioTrack.java class and getTimestamp method
+        mAudioTrackClass = (jclass) env->NewGlobalRef(env->FindClass("android/media/AudioTrack"));
+        mGetTimestampID = env->GetMethodID(mAudioTrackClass, "getTimestamp", "(Landroid/media/AudioTimestamp;)Z");
+    }
+
+    jboolean timestampAvailable = env->CallBooleanMethod(mAudioTrack, mGetTimestampID, mAudioTimestamp);
+
+    if (timestampAvailable == JNI_FALSE) {
+        return ResultWithValue(Result::ErrorUnavailable);
+    }
+
+    auto framePosition = (int64_t) env->GetLongField(mAudioTimestamp, mFramePositionField);
+    auto nanoTime = (int64_t) env->GetLongField(mAudioTimestamp, mNanoTimeField);
+
+    return ResultWithValue(new AudioTimestamp(framePosition, nanoTime));
+}

--- a/src/opensles/AudioTrack.h
+++ b/src/opensles/AudioTrack.h
@@ -10,22 +10,12 @@
 
 namespace oboe {
 
-struct AudioTimestamp {
-    int64_t framePosition;
-    int64_t nanoTime;
-
-    AudioTimestamp(int64_t framePosition, int64_t nanoTime) {
-        this->framePosition = framePosition;
-        this->nanoTime = nanoTime;
-    }
-};
-
 class AudioTrack {
 public:
     AudioTrack(const JavaVM &javaVM, jobject audioTrack);
     ~AudioTrack();
 
-    ResultWithValue<AudioTimestamp> getTimestamp();
+    ResultWithValue<FrameTimestamp> getTimestamp();
 
 private:
     // Cached JVM instance for retrieving JNIEnv

--- a/src/opensles/AudioTrack.h
+++ b/src/opensles/AudioTrack.h
@@ -12,14 +12,14 @@ namespace oboe {
 
 class AudioTrack {
 public:
-    AudioTrack(const JavaVM &javaVM, jobject audioTrack);
+    AudioTrack(JavaVM *javaVM, jobject audioTrack);
     ~AudioTrack();
 
     ResultWithValue<FrameTimestamp> getTimestamp();
 
 private:
     // Cached JVM instance for retrieving JNIEnv
-    JavaVM mJavaVM;
+    JavaVM *mJavaVM = nullptr;
 
     // Cached AudioTrack.java objects
     jclass mAudioTrackClass = nullptr;

--- a/src/opensles/AudioTrack.h
+++ b/src/opensles/AudioTrack.h
@@ -1,0 +1,48 @@
+//
+// Created by Alex Crimi on 2/15/19.
+//
+
+#ifndef OBOE_AUDIOTRACK_H
+#define OBOE_AUDIOTRACK_H
+
+#include "oboe/Oboe.h"
+#include <jni.h>
+
+namespace oboe {
+
+struct AudioTimestamp {
+    int64_t framePosition;
+    int64_t nanoTime;
+
+    AudioTimestamp(int64_t framePosition, int64_t nanoTime) {
+        this->framePosition = framePosition;
+        this->nanoTime = nanoTime;
+    }
+};
+
+class AudioTrack {
+public:
+    AudioTrack(const JavaVM &javaVM, jobject audioTrack);
+    ~AudioTrack();
+
+    ResultWithValue<AudioTimestamp> getTimestamp();
+
+private:
+    // Cached JVM instance for retrieving JNIEnv
+    JavaVM mJavaVM;
+
+    // Cached AudioTrack.java objects
+    jclass mAudioTrackClass = nullptr;
+    jmethodID mGetTimestampID;
+    jobject mAudioTrack;
+
+    // Cached AudioTimestamp.java objects
+    jclass mAudioTimestampClass = nullptr;
+    jfieldID mFramePositionField;
+    jfieldID mNanoTimeField;
+    jobject mAudioTimestamp;
+};
+
+} // namespace oboe
+
+#endif // OBOE_AUDIOTRACK_H


### PR DESCRIPTION
Implements getTimestamp() for OpenSL streams back to API 24. Passes JavaVM pointer to stream, which then uses that to interface with the associated AudioTrack.java instance and query for timestamp info via JNI